### PR TITLE
docs: fix link to autorelease from multiarch instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ jobs:
 
 _This is a workflow_
 
-All-in-one package that builds, tests, beautify and publishes a docker image for multiple architectures. This workflow uses the [Auto release](https://github.com/dfds/shared-workflows/tree/master/workflows/automation#auto-release) workflow to create a Github Release on push to master. You have to add DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets to your repository to use this workflow. To use the slack integration you will also have to add the SLACK_WEBHOOK secret.
+All-in-one package that builds, tests, beautify and publishes a docker image for multiple architectures. This workflow uses the [Auto release](#auto-release) workflow to create a Github Release on push to master. You have to add DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets to your repository to use this workflow. To use the slack integration you will also have to add the SLACK_WEBHOOK secret.
 
 How to invoke this workflow:
 


### PR DESCRIPTION
Fixes the link anchor from the multi-arch docker build instructions to the auto release section in the readme