### PR TITLE
Feat/allow setting dockerfile path in multibuild

### DIFF
--- a/.github/workflows/automation-multi-build.yml
+++ b/.github/workflows/automation-multi-build.yml
@@ -28,6 +28,10 @@ on:
       slack-notification:
         required: false
         type: boolean
+      docker-dockerfile-path:
+        required: false
+        type: string
+        default: Dockerfile
 
 jobs:
   test-container:
@@ -129,6 +133,7 @@ jobs:
           push: true
           tags: ${{ needs.collect-metadata.outputs.tags }}
           labels: ${{ needs.collect-metadata.outputs.labels }}
+          file: ${{ inputs.docker-dockerfile-path }}
       - name: Docker Hub README and Description
         if: "${{ inputs.docker-readme-path != '' }}"
         uses: dfds/dockerhub-description@main

--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ jobs:
 
       # Optional, sends a slack notification to the channel specified in the repository secrets
       slack-notification: true
+
+      # Optional, the path to the Dockerfile you wish to build. Defaults to Dockerfile at the repository root.
+      docker-dockerfile-path: "./path/to/Dockerfile"
 ```
 
 ## Compliance

--- a/README.md
+++ b/README.md
@@ -173,9 +173,6 @@ jobs:
 
       # Optional, sends a slack notification to the channel specified in the repository secrets
       slack-notification: true
-
-      # Optional, the path to the Dockerfile you wish to build. Defaults to Dockerfile at the repository root.
-      docker-dockerfile-path: "./path/to/Dockerfile"
 ```
 
 ## Compliance

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ jobs:
 
 _This is a workflow_
 
-All-in-one package that builds, tests, beautify and publishes a docker image for multiple architectures. This workflow uses the [Auto release](#auto-release) workflow to create a Github Release on push to master. You have to add DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets to your repository to use this workflow. To use the slack integration you will also have to add the SLACK_WEBHOOK secret.
+All-in-one package that builds, tests, beautify and publishes a docker image for multiple architectures. This workflow uses the [Auto release](https://github.com/dfds/shared-workflows/tree/master/workflows/automation#auto-release) workflow to create a Github Release on push to master. You have to add DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets to your repository to use this workflow. To use the slack integration you will also have to add the SLACK_WEBHOOK secret.
 
 How to invoke this workflow:
 
@@ -173,6 +173,9 @@ jobs:
 
       # Optional, sends a slack notification to the channel specified in the repository secrets
       slack-notification: true
+
+      # Optional, the path to the Dockerfile you wish to build. Defaults to Dockerfile at the repository root.
+      docker-dockerfile-path: "./path/to/Dockerfile"
 ```
 
 ## Compliance

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -7,10 +7,12 @@ Index:
 	- [Workflow naming convention](#workflow-naming-convention)
 	- [How to structure the workflow](#how-to-structure-the-workflow)
 	- [How to structure the example workflow](#how-to-structure-the-example-workflow)
+  - [Modifying an existing workflow](#modifying-an-existing-workflow)
 - [Actions](#how-to-add-an-action)
 	- [Action naming convention](#action-naming-convention)
 	- [How to structure the action](#how-to-structure-the-action)
 	- [How to structure the example action](#how-to-structure-the-example-action)
+  - [Modifying an existing action](#modifying-an-existing-action)
 - [Updating the README](#updating-the-readme)
 - [Create a pull request](#create-a-pull-request)
 
@@ -69,6 +71,10 @@ jobs:
 ```
 
 The example must be completely copy-paste ready and **not** a draft or WIP. If any modifications are required by the consumer, provide this information in the description of the example.
+
+### Modifying an existing Workflow
+
+If you need to modify an existing workflow please make best effort to ensure it is backwards compatible. If any new inputs are added please add them to the example action.
 
 ## How to add an action
 
@@ -147,9 +153,16 @@ jobs:
 
 The example must be completely copy-paste ready and **not** a draft or WIP. If any modifications are required by the consumer, provide this information in the description of the example.
 
+### Modifying an existing Action
+
+If you need to modify an existing action please make best effort to ensure it is backwards compatible. If any new inputs are added please add them to the example action.
+
 ## Updating the README
 
 The README is automatically updated if the guidelines are respected. Those changes will be appended to your PR, please verify when the automation has run.
+
+> [!WARNING]
+> Please **DO NOT** update the README manually. Ensure you update the examples if you modify an existing workflow or action to have the README updated automatically.
 
 ## Create a pull request
 

--- a/examples/automation-multi-build.yml
+++ b/examples/automation-multi-build.yml
@@ -29,3 +29,6 @@ jobs:
 
       # Optional, sends a slack notification to the channel specified in the repository secrets
       slack-notification: true
+
+      # Optional, the path to the Dockerfile you wish to build. Defaults to Dockerfile at the repository root.
+      docker-dockerfile-path: "./path/to/Dockerfile"


### PR DESCRIPTION
Currently the multi-arch docker build will only build a Dockerfile if it exists at the root of the repository and it is very often that the Dockerfile lives in some kind of build directory.

This PR will allow you to specify a path to a Dockerfile and maintain backwards compatibility by specifying a default value if a value is not specified.