### PR TITLE
Feat/require status checks

### DIFF
--- a/.github/workflows/automation-housekeeping.yml
+++ b/.github/workflows/automation-housekeeping.yml
@@ -90,9 +90,6 @@ jobs:
             "required_pull_request_reviews": null,
             "required_status_checks": {
               "strict": true,
-              "contexts": [
-                "checking-labels"
-              ],
               "checks": [
                 {
                   "context": "checking-labels",

--- a/.github/workflows/automation-housekeeping.yml
+++ b/.github/workflows/automation-housekeeping.yml
@@ -19,7 +19,7 @@ on:
         default: false
         type: boolean
       status_checks:
-        description: 'Enable mandatory status checks on PR's'
+        description: 'Enable mandatory status checks on PRs'
         required: false
         default: false
         type: boolean

--- a/.github/workflows/automation-housekeeping.yml
+++ b/.github/workflows/automation-housekeeping.yml
@@ -43,6 +43,9 @@ jobs:
   branch-protection:
     if: inputs.branch_protection == true
     runs-on: ubuntu-latest
+    concurrency:
+      group: queue
+      cancel-in-progress: false
     steps:
       - name: Checkout Repository
         uses: actions/checkout@master
@@ -83,6 +86,9 @@ jobs:
   status-checks:
     if: inputs.status_checks == true
     runs-on: ubuntu-latest
+    concurrency:
+      group: queue
+      cancel-in-progress: false
     steps:
       - name: Checkout Repository
         uses: actions/checkout@master

--- a/.github/workflows/automation-housekeeping.yml
+++ b/.github/workflows/automation-housekeeping.yml
@@ -71,7 +71,7 @@ jobs:
           w=$(jq '.required_pull_request_reviews |= {
             "dismiss_stale_reviews": true,
             "require_code_owner_reviews": false,
-            "require_last_push_approval": false,
+            "require_last_push_approval": true,
             "required_approving_review_count": 1
           }' < desired_protection.json)
 

--- a/.github/workflows/automation-housekeeping.yml
+++ b/.github/workflows/automation-housekeeping.yml
@@ -87,6 +87,7 @@ jobs:
         # if: ${{ steps.hasBranchProtection.outcome == 'failure' }}
         run: |
           echo '{
+            "required_pull_request_reviews": null,
             "required_status_checks": {
               "strict": true,
               "contexts": [
@@ -99,7 +100,8 @@ jobs:
                 }
               ]
             },
-            "enforce_admins": true
+            "enforce_admins": true,
+            "restrictions": null
           }' > tmp.json
 
           gh api --method PUT repos/{owner}/{repo}/branches/{branch}/protection --input tmp.json

--- a/.github/workflows/automation-housekeeping.yml
+++ b/.github/workflows/automation-housekeeping.yml
@@ -99,7 +99,7 @@ jobs:
                 }
               ]
             },
-            "enforce_admins": true,
+            "enforce_admins": true
           }' > tmp.json
 
           gh api --method PUT repos/{owner}/{repo}/branches/{branch}/protection --input tmp.json

--- a/.github/workflows/automation-housekeeping.yml
+++ b/.github/workflows/automation-housekeeping.yml
@@ -49,27 +49,37 @@ jobs:
         with:
           fetch-depth: 0
       - name: Get current branch protection on default branch
-        id: hasBranchProtection
         continue-on-error: true
         run: |
-          gh api repos/{owner}/{repo}/branches/{branch}/protection
-      # Only create branch protection if it doesn't exist, do not modify current settings
-      - name: Enable branch protection on default branch
-        if: ${{ steps.hasBranchProtection.outcome == 'failure' }}
-        run: |
-          echo '{
-            "required_pull_request_reviews": {
-              "dismiss_stale_reviews": true,
-              "require_code_owner_reviews": false,
-              "require_last_push_approval": false,
-              "required_approving_review_count": 1
-            },
-            "enforce_admins": true,
-            "required_status_checks": null,
-            "restrictions": null
-          }' > tmp.json
+          # Fetch the current branch protection rules
+          gh api repos/{owner}/{repo}/branches/{branch}/protection | \
+            jq '{
+              required_pull_request_reviews: .required_pull_request_reviews | del(.url),
+              enforce_admins: .enforce_admins.enabled,
+              required_status_checks: .required_status_checks | del(.url, .contexts, .contexts_url),
+              restrictions: .restrictions
+            }' > current_protection.json
 
-          gh api --method PUT repos/{owner}/{repo}/branches/{branch}/protection --input tmp.json
+          # Copy the current protection rules to a working file
+          cat current_protection.json > desired_protection.json
+      - name: Enable branch protection on default branch
+        run: |
+          # Add the desired PR review rules
+          w=$(jq '.required_pull_request_reviews |= {
+            "dismiss_stale_reviews": true,
+            "require_code_owner_reviews": false,
+            "require_last_push_approval": false,
+            "required_approving_review_count": 1
+          }' < desired_protection.json)
+
+          echo $w > desired_protection.json
+
+          # Add the 'do not bypass' rule
+          w=$(jq '.enforce_admins |= true' < desired_protection.json)
+
+          echo $w > desired_protection.json
+
+          gh api --method PUT repos/{owner}/{repo}/branches/{branch}/protection --input desired_protection.json
   status-checks:
     if: inputs.status_checks == true
     runs-on: ubuntu-latest
@@ -79,26 +89,42 @@ jobs:
         with:
           fetch-depth: 0
       - name: Get current branch protection on default branch
-        id: hasBranchProtection
         continue-on-error: true
         run: |
-          gh api repos/{owner}/{repo}/branches/{branch}/protection
-      - name: Enable mandatory status checks on PR's
-        # if: ${{ steps.hasBranchProtection.outcome == 'failure' }}
-        run: |
-          echo '{
-            "required_pull_request_reviews": null,
-            "required_status_checks": {
-              "strict": true,
-              "checks": [
-                {
-                  "context": "checking-labels",
-                  "app_id": 15368
-                }
-              ]
-            },
-            "enforce_admins": true,
-            "restrictions": null
-          }' > tmp.json
+          # Fetch the current branch protection rules
+          gh api repos/{owner}/{repo}/branches/{branch}/protection | \
+            jq '{
+              required_pull_request_reviews: .required_pull_request_reviews | del(.url),
+              enforce_admins: .enforce_admins.enabled,
+              required_status_checks: .required_status_checks | del(.url, .contexts, .contexts_url),
+              restrictions: .restrictions
+            }' > current_protection.json
 
-          gh api --method PUT repos/{owner}/{repo}/branches/{branch}/protection --input tmp.json
+          # Copy the current protection rules to a working file
+          cat current_protection.json > desired_protection.json
+      - name: Enable mandatory status checks on PR's
+        run: |
+          # Add the strict field, if it does not exist
+          w=$(jq '.required_status_checks |= . + {
+            "strict": true
+          }' < desired_protection.json)
+
+          echo $w > desired_protection.json
+
+          # Check if the on-hold status check already exists, apply if not
+          if [[ $(jq 'select(.required_status_checks.checks[]?.context == "checking-labels")' < desired_protection.json) == "" ]]; then
+            # Appends the new status check, works both if the array is null or not
+            w=$(jq '.required_status_checks.checks[.required_status_checks.checks | length] |= . + {
+              "context": "checking-labels",
+              "app_id": 15368
+            }' < desired_protection.json)
+
+            echo $w > desired_protection.json
+          fi
+
+          # Add the 'do not bypass' rule
+          w=$(jq '.enforce_admins |= true' < desired_protection.json)
+
+          echo $w > desired_protection.json
+
+          gh api --method PUT repos/{owner}/{repo}/branches/{branch}/protection --input desired_protection.json

--- a/.github/workflows/automation-housekeeping.yml
+++ b/.github/workflows/automation-housekeeping.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: false
         type: boolean
+      status_checks:
+        description: 'Enable mandatory status checks on PR's'
+        required: false
+        default: false
+        type: boolean
 
 env:
   GH_TOKEN: ${{ secrets.SHARED_WORKFLOW_HOUSEKEEPING }}
@@ -62,6 +67,39 @@ jobs:
             "enforce_admins": true,
             "required_status_checks": null,
             "restrictions": null
+          }' > tmp.json
+
+          gh api --method PUT repos/{owner}/{repo}/branches/{branch}/protection --input tmp.json
+  status-checks:
+    if: inputs.status_checks == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+      - name: Get current branch protection on default branch
+        id: hasBranchProtection
+        continue-on-error: true
+        run: |
+          gh api repos/{owner}/{repo}/branches/{branch}/protection
+      - name: Enable mandatory status checks on PR's
+        # if: ${{ steps.hasBranchProtection.outcome == 'failure' }}
+        run: |
+          echo '{
+            "required_status_checks": {
+              "strict": true,
+              "contexts": [
+                "checking-labels"
+              ],
+              "checks": [
+                {
+                  "context": "checking-labels",
+                  "app_id": 15368
+                }
+              ]
+            },
+            "enforce_admins": true,
           }' > tmp.json
 
           gh api --method PUT repos/{owner}/{repo}/branches/{branch}/protection --input tmp.json

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ jobs:
       squash_merge: true
       # Optional, Enable branch protection on default branch
       branch_protection: true
+      # Optional, Enable mandatory status checks on PR's
+      status_checks: true
 ```
 
 ### Multi architecture docker build

--- a/examples/automation-housekeeping.yml
+++ b/examples/automation-housekeeping.yml
@@ -16,3 +16,5 @@ jobs:
       squash_merge: true
       # Optional, Enable branch protection on default branch
       branch_protection: true
+      # Optional, Enable mandatory status checks on PR's
+      status_checks: true


### PR DESCRIPTION
Added an option to enable requirements of status checks before PR merge, this works in conjunction with [issue #2386](https://github.com/dfds/cloudplatform/issues/2386).

I've also improved the existing workflow, previously it would not work if you had pre-existing branch protection rules, now it merges the repos rules with this workflows rules. This modification greatly increases the use cases and decreases the risk of breaking repo specific rules.