### PR TITLE
Feature/unified test build

### DIFF
--- a/.github/workflows/automation-integration-test-build.yml
+++ b/.github/workflows/automation-integration-test-build.yml
@@ -1,0 +1,50 @@
+name: Integration test build
+
+on:
+  workflow_call:
+    inputs:
+      test-source-path:
+        description: 'Path to the Go test suite directory'
+        required: true
+        type: string
+      repository:
+        description: 'Repository to checkout (defaults to calling repo)'
+        required: false
+        type: string
+        default: ''
+      ref:
+        description: 'Git ref to checkout (defaults to calling ref)'
+        required: false
+        type: string
+        default: ''
+      artifact-name:
+        description: 'Name for the uploaded test binary artifact'
+        required: false
+        type: string
+        default: 'integration-test-binary'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: ${{ inputs.test-source-path }}/go.mod
+          cache-dependency-path: ${{ inputs.test-source-path }}/go.sum
+
+      - name: Build test binary
+        working-directory: ${{ inputs.test-source-path }}
+        run: go test -c -v -vet=off -o /tmp/test.bin
+
+      - name: Upload test binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: /tmp/test.bin

--- a/.github/workflows/automation-integration-test-build.yml
+++ b/.github/workflows/automation-integration-test-build.yml
@@ -13,7 +13,7 @@ on:
         type: string
         default: ''
       ref:
-        description: 'Git ref to checkout (defaults to calling ref)'
+        description: 'Git ref to checkout. Accepts branch names (master, feature/foo), tags (v1.0.0), full refs (refs/heads/master, refs/tags/v1.0.0), or commit SHAs. Defaults to calling ref.'
         required: false
         type: string
         default: ''

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Shared workflows and actions:
 		- [Enforce PR labels](#enforce-pr-labels)
 		- [Golang test suite](#golang-test-suite)
 		- [Housekeeping](#housekeeping)
+		- [Integration test build](#integration-test-build)
 		- [Multi architecture docker build](#multi-architecture-docker-build)
 		- [Block on-hold PRs](#block-on-hold-prs)
 		- [Add comment from PR template on Renovate pull requests](#add-comment-from-pr-template-on-renovate-pull-requests)
@@ -160,6 +161,32 @@ jobs:
       branch_protection: true
       # Optional, Enable mandatory checking-labels status check on PRs
       status_checks: true
+```
+
+### Integration test build
+
+_This is a workflow_
+
+Builds a Go integration test binary and uploads it as an artifact. Designed for infrastructure integration tests that are compiled once and run against multiple environments.
+
+How to invoke this workflow:
+
+```yaml
+name: Integration test build
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build-test:
+    uses: dfds/shared-workflows/.github/workflows/automation-integration-test-build.yml@master
+    with:
+      test-source-path: test/integration/suite
+      repository: dfds/infrastructure-modules
+      ref: master
+      artifact-name: test-binary
+
 ```
 
 ### Multi architecture docker build

--- a/examples/automation-integration-test-build.yml
+++ b/examples/automation-integration-test-build.yml
@@ -9,7 +9,7 @@ jobs:
   build-test:
     uses: dfds/shared-workflows/.github/workflows/automation-integration-test-build.yml@master
     with:
-      test-source-path: test/integration/suite #Path to the Go test suite directory
-      repository: dfds/infrastructure-modules #Repository to checkout (optional, defaults to calling repo)
-      ref: master #Git ref to checkout (optional, defaults to calling ref)
-      artifact-name: test-binary #Name for the uploaded artifact (optional, defaults to integration-test-binary)
+      test-source-path: test/integration/suite
+      repository: dfds/infrastructure-modules
+      ref: master
+      artifact-name: test-binary

--- a/examples/automation-integration-test-build.yml
+++ b/examples/automation-integration-test-build.yml
@@ -1,0 +1,15 @@
+name: Integration test build
+description: Builds a Go integration test binary and uploads it as an artifact. Designed for infrastructure integration tests that are compiled once and run against multiple environments.
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build-test:
+    uses: dfds/shared-workflows/.github/workflows/automation-integration-test-build.yml@master
+    with:
+      test-source-path: test/integration/suite #Path to the Go test suite directory
+      repository: dfds/infrastructure-modules #Repository to checkout (optional, defaults to calling repo)
+      ref: master #Git ref to checkout (optional, defaults to calling ref)
+      artifact-name: test-binary #Name for the uploaded artifact (optional, defaults to integration-test-binary)


### PR DESCRIPTION
This pull request introduces a reusable GitHub Actions workflow for building Go integration test binaries and provides an example of how to use it. The main focus is on enabling consistent, artifact-based integration testing across repositories.

**Reusable workflow creation:**

* Added `.github/workflows/automation-integration-test-build.yml`, which defines a workflow for building a Go integration test binary and uploading it as an artifact. It supports configurable inputs for source path, repository, ref, and artifact name.

**Usage example:**

* Added `examples/automation-integration-test-build.yml`, demonstrating how to consume the reusable workflow from another workflow, specifying the test source path, repository, ref, and artifact name.