### PR TITLE
Add runner/container inputs to integration-test-build

### DIFF
--- a/.github/workflows/automation-integration-test-build.yml
+++ b/.github/workflows/automation-integration-test-build.yml
@@ -22,10 +22,21 @@ on:
         required: false
         type: string
         default: 'integration-test-binary'
+      runner:
+        description: 'Runner label to execute the build on. Defaults to GitHub-hosted ubuntu-latest; pass a self-hosted label (e.g. dfds-runners) to avoid GHA minutes billing.'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      container:
+        description: 'Optional container image to run the build in. Useful when the runner does not have Go pre-installed (e.g. dfdsdk/prime-pipeline). When set, actions/setup-go is skipped.'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
+    container: ${{ inputs.container }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -34,6 +45,7 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Setup Go
+        if: inputs.container == ''
         uses: actions/setup-go@v6
         with:
           go-version-file: ${{ inputs.test-source-path }}/go.mod


### PR DESCRIPTION
This pull request updates the `.github/workflows/automation-integration-test-build.yml` workflow to make the build environment more flexible and configurable. The main improvements are the ability to select a custom runner and optionally run the build inside a specified container, which is useful for environments where Go is not pre-installed.

**Build environment flexibility:**

* Added a `runner` input to allow specifying a custom runner label (e.g., for self-hosted runners), defaulting to `ubuntu-latest`. The workflow now uses this input for the `runs-on` property.
* Added a `container` input to optionally run the build inside a specified container image. If set, the workflow uses this image for the build job and skips setting up Go with `actions/setup-go`. [[1]](diffhunk://#diff-3976ffb30e2c1b1df404a4e56d511029c63832ecec4bebdcbd42c1b98e605de3R25-R39) [[2]](diffhunk://#diff-3976ffb30e2c1b1df404a4e56d511029c63832ecec4bebdcbd42c1b98e605de3R48)

**Conditional setup:**

* The `actions/setup-go` step is now conditional and only runs if the `container` input is not set, preventing redundant Go installation when a container image already provides Go.