### PR TITLE
Add ECR pull-through cache warm reusable workflow

### DIFF
--- a/.github/workflows/automation-ecr-warm-cache.yml
+++ b/.github/workflows/automation-ecr-warm-cache.yml
@@ -1,0 +1,89 @@
+name: ECR cache warm
+
+on:
+  workflow_call:
+    inputs:
+      role-to-assume:
+        description: 'AWS IAM role ARN to assume via OIDC. Needs ecr:GetAuthorizationToken plus pull-through cache permissions (ecr:BatchImportUpstreamImage, ecr:CreateRepository, ecr:BatchGetImage, ecr:BatchCheckLayerAvailability, ecr:GetDownloadUrlForLayer).'
+        required: true
+        type: string
+      aws-region:
+        description: 'AWS region of the ECR registry. Defaults to eu-west-1.'
+        required: false
+        type: string
+        default: 'eu-west-1'
+      workflow-glob:
+        description: 'Glob of workflow files to scan for ECR image references. Defaults to all GitHub Actions workflows in the calling repo.'
+        required: false
+        type: string
+        default: '.github/workflows/*.yml .github/workflows/*.yaml'
+
+jobs:
+  warm:
+    name: Warm ECR pull-through cache
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ inputs.role-to-assume }}
+          role-session-name: ecr-warm-cache
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Extract ECR image references
+        id: extract
+        run: |
+          set -euo pipefail
+          # Scan workflow files for <account>.dkr.ecr.<region>.amazonaws.com/<path>:<tag>
+          IMAGES=$(grep -hoE '[0-9]{12}\.dkr\.ecr\.[a-z0-9-]+\.amazonaws\.com/[a-zA-Z0-9./_-]+:[a-zA-Z0-9._-]+' ${{ inputs.workflow-glob }} 2>/dev/null | sort -u || true)
+          if [ -z "$IMAGES" ]; then
+            echo "No ECR image references found in workflows — nothing to warm."
+            echo "images=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Found the following ECR image references:"
+          echo "$IMAGES"
+          # Multiline output for downstream steps
+          {
+            echo "images<<EOF"
+            echo "$IMAGES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Log in to ECR and pull images
+        if: steps.extract.outputs.images != ''
+        env:
+          IMAGES: ${{ steps.extract.outputs.images }}
+        run: |
+          set -euo pipefail
+          # Log in once per unique registry (in case multiple accounts/regions appear)
+          REGISTRIES=$(echo "$IMAGES" | awk -F/ '{print $1}' | sort -u)
+          for REGISTRY in $REGISTRIES; do
+            REGION=$(echo "$REGISTRY" | awk -F. '{print $4}')
+            echo "Authenticating to $REGISTRY (region $REGION)"
+            aws ecr get-login-password --region "$REGION" | \
+              docker login --username AWS --password-stdin "$REGISTRY"
+          done
+          # Pull every unique image. A successful pull either confirms the
+          # image was already cached or triggers the pull-through cache to
+          # fetch it from upstream, making it available for self-hosted
+          # runners with short kubelet pull timeouts.
+          FAILED=0
+          while IFS= read -r IMAGE; do
+            [ -z "$IMAGE" ] && continue
+            echo "::group::Pulling $IMAGE"
+            if docker pull "$IMAGE"; then
+              echo "::endgroup::"
+            else
+              echo "::endgroup::"
+              echo "::error::Failed to pull $IMAGE — check upstream availability and pull-through cache configuration."
+              FAILED=1
+            fi
+          done <<< "$IMAGES"
+          exit $FAILED

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Shared workflows and actions:
 	- workflows
 		- [Auto release](#auto-release)
 		- [Build lambda and upload to S3](#build-lambda-and-upload-to-s3)
+		- [ECR cache warm check](#ecr-cache-warm-check)
 		- [Enforce PR labels](#enforce-pr-labels)
 		- [Golang test suite](#golang-test-suite)
 		- [Housekeeping](#housekeeping)
@@ -84,6 +85,34 @@ jobs:
       arguments: PACKAGE_NAME=${{ matrix.lambda-name }} #The arguments to be passed to make
     secrets:
       role-to-assume: ${{ secrets.ROLE_TO_ASSUME }} #Repository secret with the AWS role to be assumed
+
+```
+
+### ECR cache warm check
+
+_This is a workflow_
+
+Pulls every ECR image referenced in the calling repo's GitHub Actions workflows so the pull-through cache is materialized before self-hosted runners (with their short kubelet image-pull timeouts) try to pull them. Trigger on PRs that modify workflows to catch container tag bumps before merge.
+
+How to invoke this workflow:
+
+```yaml
+name: ECR cache warm check
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+
+jobs:
+  warm-cache:
+    uses: dfds/shared-workflows/.github/workflows/automation-ecr-warm-cache.yml@master
+    with:
+      role-to-assume: arn:aws:iam::123456789012:role/github-actions-ecr-warm-cache
+      aws-region: eu-west-1
+    permissions:
+      id-token: write
+      contents: read
 
 ```
 

--- a/examples/automation-ecr-warm-cache.yml
+++ b/examples/automation-ecr-warm-cache.yml
@@ -1,0 +1,17 @@
+name: ECR cache warm check
+description: Pulls every ECR image referenced in the calling repo's GitHub Actions workflows so the pull-through cache is materialized before self-hosted runners (with their short kubelet image-pull timeouts) try to pull them. Trigger on PRs that modify workflows to catch container tag bumps before merge.
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+
+jobs:
+  warm-cache:
+    uses: dfds/shared-workflows/.github/workflows/automation-ecr-warm-cache.yml@master
+    with:
+      role-to-assume: arn:aws:iam::123456789012:role/github-actions-ecr-warm-cache
+      aws-region: eu-west-1
+    permissions:
+      id-token: write
+      contents: read


### PR DESCRIPTION
This pull request introduces a new reusable GitHub Actions workflow for warming up ECR pull-through caches, along with an example of how to use it in a repository. The main goal is to proactively pull all ECR images referenced in workflow files, ensuring they are available in the cache before self-hosted runners need them, which helps avoid timeouts.

**New ECR cache warming workflow:**

* [`.github/workflows/automation-ecr-warm-cache.yml`](diffhunk://#diff-ac6b98de589f7cfdf3eb8033a5f56e136bbdfb782cc79ab383829978811273abR1-R89): Adds a reusable workflow that scans workflow files for ECR image references, logs into each unique ECR registry, and pulls all referenced images to warm the pull-through cache. This includes robust error handling and support for multiple registries and regions.

**Example usage:**

* [`examples/automation-ecr-warm-cache.yml`](diffhunk://#diff-4b8e27dc87d7112fd90ffadcf96a42e0fae5ea51154ea63c0ce1d01ac3286798R1-R17): Provides an example workflow that triggers on pull requests modifying workflow files. It calls the new reusable workflow, specifying the required IAM role and region, and sets appropriate permissions.