### PR TITLE
Update implementation jobs to use local workflows properly

### DIFF
--- a/.github/workflows/implementation-auto-release.yaml
+++ b/.github/workflows/implementation-auto-release.yaml
@@ -12,8 +12,4 @@ on:
 
 jobs:
   auto-release:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: ./.github/workflows/automation-enforce-release-labels.yml
+      uses: ./.github/workflows/automation-auto-release.yml

--- a/.github/workflows/implementation-auto-release.yaml
+++ b/.github/workflows/implementation-auto-release.yaml
@@ -2,18 +2,13 @@ name: Auto release on merge (Implementation)
 
 on:
   push:
-    branches: ["master", "main"]
+    branches:
+      - master
     paths-ignore:
-      - ".github/**"
-      - ".trunk/**"
-      - "**/*.md"
       - ".gitignore"
-      - ".pre-commit-config.yaml"
-      - "LICENSE"
+      - "**/*.md"
+      - "docs/**"
       - "renovate.json"
-      - "test/**"
-      - "src/**"
-      - "mise.toml"
 
 jobs:
   auto-release:
@@ -21,7 +16,4 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: rymndhng/release-on-push-action@master
-        with:
-          bump_version_scheme: patch
-          tag_prefix: ""
+      - uses: ./.github/workflows/automation-enforce-release-labels.yml

--- a/.github/workflows/implementation-enforce-labels.yaml
+++ b/.github/workflows/implementation-enforce-labels.yaml
@@ -3,12 +3,9 @@ name: Enforce PR labels (Implementation)
 on:
   pull_request:
     types: [labeled, unlabeled, opened, edited, synchronize]
-    branches: [ "master", "main" ]
+    branches:
+      - master
+
 jobs:
   enforce-label:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: yogevbd/enforce-label-action@2.2.2
-      with:
-        REQUIRED_LABELS_ANY: "release:minor,release:major,release:patch,release:norelease,norelease"
-        REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label ['release:minor','release:major','release:patch','release:norelease','norelease']"
+    uses: ./.github/workflows/automation-enforce-release-labels.yml

--- a/.github/workflows/implementation-housekeeping.yaml
+++ b/.github/workflows/implementation-housekeeping.yaml
@@ -2,13 +2,13 @@ name: Housekeeping (Implementation)
 
 on:
   schedule:
-    - cron: "0 6 * * *"
+    - cron: "0 2 * * *"
 
   workflow_dispatch:
 
 jobs:
   shared:
-    uses: dfds/shared-workflows/.github/workflows/automation-housekeeping.yml@master
+    uses: ./.github/workflows/automation-housekeeping.yml
     secrets: inherit
     with:
       delete_head_branch: true


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use local workflow files instead of remote or inline configurations, and makes minor adjustments to scheduling and branch targeting. These changes centralize workflow logic and improve maintainability.

**Workflow file refactoring:**

* The `auto-release` job in `.github/workflows/implementation-auto-release.yaml` now uses the local reusable workflow `.github/workflows/automation-auto-release.yml` instead of an inline configuration. The branch filter is simplified to only `master`, and the `paths-ignore` list is updated to focus on documentation and configuration files.
* The `enforce-label` job in `.github/workflows/implementation-enforce-labels.yaml` now uses the local reusable workflow `.github/workflows/automation-enforce-release-labels.yml` instead of the external `enforce-label-action`. The branch filter is also simplified to only `master`.
* The `shared` job in `.github/workflows/implementation-housekeeping.yaml` now uses the local reusable workflow `.github/workflows/automation-housekeeping.yml` instead of the remote `dfds/shared-workflows` workflow. The housekeeping schedule is changed to run at 2:00 AM UTC instead of 6:00 AM UTC.